### PR TITLE
springcloud-config的分布式配置中心的服务端简单的配置和使用可以通过ip+端口/git仓库的具体文件路径访问(http:/…

### DIFF
--- a/cloud-config-center-3344/pom.xml
+++ b/cloud-config-center-3344/pom.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>cloud2020</artifactId>
+        <groupId>com.atguigu.springcloud</groupId>
+        <version>1.0-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>cloud-config-center-3344</artifactId>
+
+    <dependencies>
+        <!--springCloud的分布式配置中心（指定是服务端）-->
+        <dependency>
+            <groupId>org.springframework.cloud</groupId>
+            <artifactId>spring-cloud-config-server</artifactId>
+        </dependency>
+        <!--springCloud的eureka的客户端依赖，标记此服务作为eureka的客户端向eureka的服务端注册-->
+        <dependency>
+            <groupId>org.springframework.cloud</groupId>
+            <artifactId>spring-cloud-starter-netflix-eureka-client</artifactId>
+        </dependency>
+        <!--springboot的web启动包-->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+        <!--springboot监控坐标通常和springboot中web启动类一起使用为了和dashboard监控仪表盘界面看到信息-->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-actuator</artifactId>
+        </dependency>
+        <!--springboot热部署工具-->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-devtools</artifactId>
+            <scope>runtime</scope>
+            <optional>true</optional>
+        </dependency>
+        <!--lombok坐标，引入此坐标可减少实体类中setterAndgetter等相关冗余代码-->
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <!--springboot整合单元测试相关坐标-->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/cloud-config-center-3344/src/main/java/com/atguigu/springcloud/ConfigApplication3344.java
+++ b/cloud-config-center-3344/src/main/java/com/atguigu/springcloud/ConfigApplication3344.java
@@ -1,0 +1,21 @@
+package com.atguigu.springcloud;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cloud.client.discovery.EnableDiscoveryClient;
+import org.springframework.cloud.config.server.EnableConfigServer;
+
+/**
+ * description: ConfigApplication3344 <br>
+ * date: 2020/10/9 14:05 <br>
+ * author: sttdev <br>
+ * version: 1.0 <br>
+ */
+@SpringBootApplication            //springboot的启动类注解
+@EnableDiscoveryClient           //服务发现(服务注册到eureka的注册中心中)
+@EnableConfigServer             //开启Springcloud的分布式配置中心的服务端
+public class ConfigApplication3344 {
+    public static void main(String[] args) {
+        SpringApplication.run(ConfigApplication3344.class,args);
+    }
+}

--- a/cloud-config-center-3344/src/main/resources/application.yml
+++ b/cloud-config-center-3344/src/main/resources/application.yml
@@ -1,0 +1,48 @@
+server:
+  port: 3344                  #端口号
+
+
+spring:
+  application:
+    name: config-server      #服务名称
+  cloud:
+    config:
+      server:
+        git:
+          uri: https://github.com/Json-spec/springcloud-config.git          #分布式配置中心配置文件的远程仓库的地址
+          #username: 1654624759@qq.com                                      #github账号
+          #password: 52013145257LSs                                         #github密码     注如果git仓库是私有的需要配置用户名密码公开的不需要配置
+          search-paths: springcloud-config                                 #配置远程仓库读取路径
+      label: master                                                        #配置仓库的分支
+  http:                                                                    #解决分布式配置中心读取远程配置出现中文乱码的情况
+    encoding:
+      charset: UTF-8
+      enabled: true
+      force: true
+
+eureka:
+  instance:
+    hostname: localhost                                                                               #主机名称可以是ip
+  client:
+    fetch-registry: true                                                                              # 是否拉取其它服务的信息，默认是true
+    register-with-eureka: true                                                                        # 是否注册自己的信息到EurekaServer，默认是true
+    serviceUrl:
+      defaultZone: http://${eureka.instance.hostname}:7001/eureka/                                    #指定服务客户端要注册到那个注册中的具体地址
+
+
+#访问地址例如； http://localhost:3344/config-dev.yml    ,    http://localhost:3344/config-test.yml   可在浏览器中看见git仓库配置的具体配置信息(springcloud-config服务端访问)
+#启动分布式注册中心服务可通过一下方式进行访问远程配置
+ # /{application}/{profile}[/{label}]
+ # /{application}-{profile}.yml
+ # /{label}/{application}-{profile}.yml
+ # /{application}-{profile}.properties
+ # /{label}/{application}-{profile}.properties
+#label : git仓库的分支
+#application ：配置文件的文件名，如我的残酷里的clientOne.yml 中的“clientOne”，对应服务的应用名，这个后面再说
+#profile：这个很熟悉，配置文件的后缀，可以对应服务启用的环境
+#访问配置文件
+#默认访问
+#默认访问的是master分支
+
+
+

--- a/pom.xml
+++ b/pom.xml
@@ -26,6 +26,7 @@
         <module>cloud-hystrix-test-server9000</module>
         <module>cloud-hystrix-test-dashboard</module>
         <module>cloud-gateway-gateway9527</module>
+        <module>cloud-config-center-3344</module>
     </modules>
     <packaging>pom</packaging>
 


### PR DESCRIPTION
…/127.0.0.1:3344/config-dev.yml)